### PR TITLE
Rules update

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -4,21 +4,43 @@ COURSE_RUN_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 # Rules for automated Programs creation:
 RULES_PROGRAM_TYPE_NAME = 'Rules'
 PROGRAM_RULES = [
-    {'name': '[14 Hour Bundle] Two 7-hour courses', 7: 2, 'uspap': False},
-    {'name': '[14 Hour Bundle] 7-hour course and 2018-2019 USPAP course', 7: 2, 'uspap': True},
-    {'name': '[21 Hour Bundle] Three 7 hour courses', 7: 3},
+    {
+        'name': '[14 Hour Bundle] Two 7-hour courses',
+        7: 2,
+        'uspap': False
+    },
+    {
+        'name': '[14 Hour Bundle] 7-hour course and 2018-2019 USPAP course',
+        7: 2,
+        'uspap': True
+    },
+    {
+        'name': '[21 Hour Bundle] Three 7 hour courses',
+        7: 3,
+        'uspap': False
+    },
     {
         'name': '[21 Hour Bundle] 8-hour course, 7-hour course and two 3-hour courses',
         8: 1, 7: 1, 3: 2,
         'uspap': False
     },
-    {'name': '[20 Hour Bundle] Two 7-hour courses and two 3-hour courses', 7: 2, 3: 2, 'uspap': False},
-    {'name': '[28 Hour Bundle] Four 7-hour courses', 7: 4},
+    {
+        'name': '[20 Hour Bundle] Two 7-hour courses and two 3-hour courses',
+        7: 2, 3: 2,
+        'uspap': False
+    },
+    {
+        'name': '[28 Hour Bundle] Four 7-hour courses',
+        7: 4,
+    },
     {
         'name': '[28 Hour Bundle] Two 7-hour courses, one 8-hour course and two 3-hour courses',
-        8: 1, 7: 2, 3: 2
+        8: 1, 7: 2, 3: 2,
     },
-    {'name': '[30 Hour Bundle] Three 7-hour courses and three 3-hour courses', 7: 3, 3: 3},
+    {
+        'name': '[30 Hour Bundle] Three 7-hour courses and three 3-hour courses',
+        7: 3, 3: 3,
+    },
     {
         'name': '[50 Hour Bundle] Five 7-hour courses, 8-hour course, 4-hour course and 3-hour course',
         8: 1, 7: 5, 4: 1, 3: 1,

--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -2,7 +2,7 @@ COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+'
 COURSE_RUN_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 
 # Rules for automated Programs creation:
-RULES_PROGRAM_TYPE_NAME = 'Rules'
+RULES_PROGRAM_TYPE_NAME = 'Bundles'
 PROGRAM_RULES = [
     {
         'name': '[14 Hour Bundle] Two 7-hour courses',

--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -47,3 +47,14 @@ PROGRAM_RULES = [
         'uspap': True
     },
 ]
+
+BUNDLES_PRICES = {
+    '[14 Hour Bundle] 7-hour course and 2018-2019 USPAP course': 199,
+    '[21 Hour Bundle] Three 7 hour courses': 269,
+    '[21 Hour Bundle] 8-hour course, 7-hour course and two 3-hour courses': 289,
+    '[20 Hour Bundle] Two 7-hour courses and two 3-hour courses': 259,
+    '[28 Hour Bundle] Four 7-hour courses': 449,
+    '[28 Hour Bundle] Two 7-hour courses, one 8-hour course and two 3-hour courses': 449,
+    '[30 Hour Bundle] Three 7-hour courses and three 3-hour courses': 469,
+    '[50 Hour Bundle] Five 7-hour courses, 8-hour course, 4-hour course and 3-hour course': 599,
+}

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -221,6 +221,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
 
         try:
             if body['effort'] is None:
+                defaults['program_duration'] = None
+                defaults['program_type'] = None
                 logger.warn(
                     "[RG: customization] - automate programs generation params are absent! "
                     "Setup `course.effort` (formats expected: `number` or `number:string`) to be able to "

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -13,7 +13,9 @@ from stdimage.utils import UploadTo
 
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.choices import ProgramStatus
-from course_discovery.apps.course_metadata.constants import RULES_PROGRAM_TYPE_NAME, PROGRAM_RULES
+from course_discovery.apps.course_metadata.constants import (
+    RULES_PROGRAM_TYPE_NAME, PROGRAM_RULES, BUNDLES_PRICES,
+)
 from course_discovery.apps.course_metadata.exceptions import MarketingSiteAPIClientException
 
 RESERVED_ELASTICSEARCH_QUERY_OPERATORS = ('AND', 'OR', 'NOT', 'TO',)
@@ -331,6 +333,9 @@ def create_programs():
     generated = 0
     skipped = 0
 
+    def get_bundle_price(rule_name):
+        return BUNDLES_PRICES.get(rule_name)
+
     def already_exists(title, bundle, programs):
         bundle_set = set(map(lambda c: c['uuid'], bundle))
         for program in programs:
@@ -342,6 +347,7 @@ def create_programs():
         return False
 
     for rule_name, bundles in bundles_dict.items():
+        bundle_price = get_bundle_price(rule_name) or 0.00
         for i, bundle in enumerate(bundles, 1):
             title = 'Program-{} {}'.format(i, rule_name)
 
@@ -355,6 +361,7 @@ def create_programs():
                 type=p_type,
                 partner=partner,
                 marketing_slug='{}-program-{}'.format(rule_name, i),
+                price=bundle_price,
             )
             program.save()
             generated += 1


### PR DESCRIPTION
[CALYPSO-136](https://youtrack.raccoongang.com/issue/CALYPSO-136)

1) Fixed rule: 21 hours bundle three 7-hour courses; 21 hour bundles CANNOT include the USPAP course;

2) Fixed: Courses with empty Effort weren't updated (Programs generation indicator) settings must be ignored during Programs Generation.

3) Change `Rules` ProgramType name to `Bundles`;

[CALYPSO-137](https://youtrack.raccoongang.com/issue/CALYPSO-137)

- Programs auto-pricing;

`NOTE:` right after update course_metadata.ProgramType with `Rules` (with all related programs) name must be destroyed in order to prevent Programs names collision.