### PR TITLE
fix: [HARROW_6-4839] self-heal free-course seats in ecommerce loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -444,9 +444,17 @@ class EcommerceApiDataLoader(AbstractDataLoader):
         has_empty_type = (Q(type=empty_course_type, course_runs__seats__isnull=False) |
                           Q(course_runs__type=empty_course_run_type, course_runs__seats__isnull=False))
         for course in Course.everything.filter(has_empty_type, partner=self.partner).distinct().iterator():
+            # Self-heal free (honor/audit) courses whose data left some runs seatless.
+            # calculate_course_type cannot upgrade an 'empty' course that mixes seated and
+            # seatless runs (a seatless run matches only the empty CourseRunType), so clone
+            # the course's existing free seat onto its seatless runs first. Paid/entitlement
+            # courses are left untouched and fall through to the manual-review path below.
+            self._heal_free_course_seats(course)
             if not calculate_course_type(course, commit=True):
-                logger.warning('Calculating course type failure occurred for [%s].', course)
-                self.processing_failure_occurred = True
+                # A single un-typeable course must not abort the entire refresh: raising here
+                # blocks deletes and leaves the whole catalog stale. Log and skip instead; the
+                # course keeps its 'empty' type until its seat data is corrected.
+                logger.warning('Calculating course type failure occurred for [%s]; skipping.', course)
 
         if (self.course_run_count != course_runs['count'] or
                 self.entitlement_count != entitlements['count'] or
@@ -454,6 +462,37 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             # The count expected should match the count received
             logger.warning('There is a mismatch in the expected count of results and the actual results.')
             self.processing_failure_occurred = True
+
+    def _heal_free_course_seats(self, course):
+        """
+        Clone a free seat onto the seatless runs of an all-free course.
+
+        Ensures every run of a course whose seats are all honor/audit carries a seat,
+        so calculate_course_type can upgrade the course instead of failing the whole
+        refresh. Idempotent (a no-op once every run is seated) and a no-op for any
+        course that has a paid/entitlement seat (those need manual review).
+        """
+        runs = list(course.course_runs.all())
+        seats = [seat for run in runs for seat in run.seats.all()]
+        if not seats:
+            return
+        free_types = {Seat.HONOR, Seat.AUDIT}
+        if any(seat.type_id not in free_types for seat in seats):
+            return
+        template = seats[0]
+        for run in runs:
+            if run.seats.exists():
+                continue
+            logger.info('Healing seatless run [%s]: cloning [%s] seat.', run.key, template.type_id)
+            Seat.objects.create(
+                course_run=run,
+                type=template.type,
+                price=template.price,
+                currency=template.currency,
+                credit_provider=template.credit_provider,
+                credit_hours=template.credit_hours,
+                draft=run.draft,
+            )
 
     def _pagerange(self, count):
         pages = int(math.ceil(count / self.PAGE_SIZE))

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -1128,8 +1128,13 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         audit_run.course.type = CourseType.objects.get(slug=CourseType.PROFESSIONAL)
         audit_run.course.save()
 
-        with pytest.raises(CommandError):
+        # A single un-typeable course must no longer abort the whole ingest: it is logged
+        # and skipped so the rest of the catalog still refreshes (and deletes still run).
+        with mock.patch(LOGGER_PATH) as mock_logger:
             self.loader.ingest()
+        mock_logger.warning.assert_any_call(
+            'Calculating course type failure occurred for [%s]; skipping.', mock.ANY
+        )
 
         # Audit will have failed to match and nothing should have changed
         audit_run = CourseRun.objects.get(key='audit/course/run')
@@ -1152,6 +1157,39 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         audit_run = CourseRun.objects.get(key='audit/course/run')
         assert audit_run.type.slug == CourseType.AUDIT
         assert audit_run.course.type.slug == CourseType.AUDIT
+
+    def test_heal_free_course_seats(self):
+        """ Verify seatless runs of an all-free course get the course's free seat cloned. """
+        honor = SeatTypeFactory.honor()
+        course = CourseFactory(partner=self.partner)
+        seated_run = CourseRunFactory(course=course, key='honor/course/run1')
+        seatless_run = CourseRunFactory(course=course, key='honor/course/run2')
+        template = SeatFactory(course_run=seated_run, type=honor)
+        assert seatless_run.seats.count() == 0
+
+        self.loader._heal_free_course_seats(course)
+
+        cloned = seatless_run.seats.get()
+        assert cloned.type == honor
+        assert cloned.price == template.price
+        assert cloned.currency == template.currency
+        # The clone carries no ecommerce identity (there is no product for a free course).
+        assert cloned.sku is None
+
+        # Idempotent: a second pass adds nothing.
+        self.loader._heal_free_course_seats(course)
+        assert seatless_run.seats.count() == 1
+
+    def test_heal_free_course_seats_skips_paid_course(self):
+        """ Verify a course with any paid/entitlement seat is left untouched (manual review). """
+        course = CourseFactory(partner=self.partner)
+        seated_run = CourseRunFactory(course=course, key='paid/course/run1')
+        seatless_run = CourseRunFactory(course=course, key='paid/course/run2')
+        SeatFactory(course_run=seated_run, type=SeatTypeFactory.verified())
+
+        self.loader._heal_free_course_seats(course)
+
+        assert seatless_run.seats.count() == 0
 
 
 @ddt.ddt


### PR DESCRIPTION
> ❌ **NOT CHOSEN for HARROW_6-4839** — superseded by Approach B ([#19](https://github.com/raccoongang/course-discovery/pull/19) + [!33](https://gitlab.raccoongang.com/hippoteam/harrow/teak/edx-platform/-/merge_requests/33)), verified red→green on harrowcn-dev. Kept open as a fallback only.
> ℹ️ **Still relevant:** the B1 resilience part of this PR (skip an untypeable course instead of aborting the whole ingest) is **not** in Approach B. [#20](https://github.com/raccoongang/course-discovery/pull/20) fixed the specific audit-seat cause on Global stage, but a course with a mix of seated and seatless runs — or a run whose LMS course has no `CourseMode` at all (28 of 61 runs on Global stage) — still aborts the refresh.

## What

`refresh_course_metadata` aborted the **entire** sync whenever `calculate_course_type` could not upgrade an `empty`-typed course that has a **mix** of runs — some carrying a free `honor`/`audit` seat, some with no seat at all. A seatless run matches only the `empty` CourseRunType (which belongs to no real CourseType), so the loader set `processing_failure_occurred` → raised `CommandError` → the catalog-refresh cron stayed red and the catalog never refreshed.

Root cause is an inherited data shape: free/honor courses have **no auto-seat path** on Teak (seats come only from the ecommerce loader, which needs an ecommerce product), so migrated inconsistencies left some free-course runs seatless. A one-shot SQL backfill did not persist — any discovery reload restores the source shape and the cron breaks again.

This fix moves the healing into the loader so it re-runs on every refresh:

- **Self-heal:** `_heal_free_course_seats()` clones a course's existing free (honor/audit) seat onto its seatless runs before the upgrade loop, so the course resolves to its real `honor`/`audit` CourseType. Idempotent; paid/entitlement courses are left untouched (reported for manual review).
- **Resilience:** a course-type calc failure is now logged and skipped instead of setting `processing_failure_occurred`/raising `CommandError`, so a single un-typeable course can no longer abort the whole refresh (which also blocked deletes).

## Verify

Reproduced and verified on a local discovery instance:

1. Seed a free course with two runs — one with an `honor` seat, one seatless (mixed state).
2. Before: `calculate_course_type(course)` → `False`, course stays `empty` (the cron-breaking condition).
3. After: the seatless run is healed with a cloned `honor` seat → `calculate_course_type` → `True`, course upgrades to `honor`. Second pass is idempotent (no duplicate seat).
4. Paid/entitlement (`verified`) mixed course: left untouched (no clone) → falls through to the log-and-skip path.
5. Durability: heal → simulate a discovery reload (drop the cloned seat, restore source shape) → next refresh re-heals → still green. Control (without the fix, same data) → red.

CI runs the unit tests: `test_heal_free_course_seats`, `test_heal_free_course_seats_skips_paid_course`, and the updated `test_upgrade_empty_types` (now asserts the failure is logged-and-skipped rather than fatal).

## Risks

- Only clones seats for courses whose seats are **all** free (honor/audit); paid/entitlement courses are never auto-seated, preserving their nuanced seat/entitlement shape.
- A course left with no free seat at all (e.g. all runs seatless after a reload) has no clone template — it is not a "mix", so it does not trigger the failure; if any edge case still fails to type, it is now skipped rather than aborting the sync.
- Cloned seats carry no SKU (there is no ecommerce product for a free course), matching the absence of an ecommerce identity.

## Ticket

- [HARROW_6-4839](https://youtrack.raccoongang.com/issue/HARROW_6-4839) -- [Global] discovery refresh_course_metadata cron fails again on PRODGT (recurrence of HARROW_6-4745)


