### PR TITLE
feat: [HARROW_6-4839] source free-course seats from LMS modes

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -130,6 +130,12 @@ class CoursesApiDataLoader(AbstractDataLoader):
                 if created:
                     logger.info(f"Course created with uuid {course.uuid} and key {course.key}")
 
+            # Materialize free (honor/audit) seats from the authoritative LMS
+            # enrollment modes. Discovery otherwise learns seats only from
+            # ecommerce, which carries no products for free courses -- so their
+            # runs stay seatless and untypeable. See update_free_seats.
+            self.update_free_seats(course_run, body)
+
             # Ensure course has a canonical run and update its metadata
             if course:
                 if not course.canonical_course_run:
@@ -331,6 +337,55 @@ class CoursesApiDataLoader(AbstractDataLoader):
             video, __ = Video.objects.get_or_create(src=video_url)
 
         return video
+
+    # Free enrollment modes whose seats are owned by this (LMS) loader rather
+    # than by the ecommerce loader. Ecommerce carries no products for these on
+    # free courses, so the LMS CourseMode table is their only source of truth.
+    FREE_SEAT_TYPES = frozenset({Seat.HONOR, Seat.AUDIT})
+
+    def update_free_seats(self, course_run, body):
+        """
+        Sync a run's free (honor/audit) seats from the authoritative LMS modes.
+
+        Paid seats (verified/professional/credit/...) stay owned by
+        EcommerceApiDataLoader; this only ever touches honor/audit. Idempotent,
+        and a no-op when the LMS payload carries no 'modes' key (an LMS that
+        predates the enrollment-modes field), so it degrades safely.
+        """
+        modes = body.get('modes')
+        if modes is None:
+            return
+        lms_free = {mode.get('slug') for mode in modes if mode.get('slug') in self.FREE_SEAT_TYPES}
+
+        try:
+            currency = Currency.objects.get(code='USD')
+        except Currency.DoesNotExist:  # pragma: no cover
+            logger.warning('Default currency USD not found; skipping free-seat sync for [%s].', course_run.key)
+            return
+
+        for slug in lms_free:
+            try:
+                seat_type = SeatType.objects.get(slug=slug)
+            except SeatType.DoesNotExist:
+                logger.warning('LMS reported unknown free seat type [%s] for run [%s]; skipping.', slug, course_run.key)
+                continue
+            seat, created = course_run.seats.update_or_create(
+                type=seat_type, currency=currency, defaults={'price': 0},
+            )
+            if course_run.draft_version:
+                draft_seat, __ = course_run.draft_version.seats.update_or_create(
+                    draft=True, type=seat_type, currency=currency, defaults={'price': 0},
+                )
+                seat.draft_version = draft_seat
+                seat.save()
+            if created:
+                logger.info('Created free [%s] seat for run [%s] from LMS modes.', slug, course_run.key)
+
+        # Prune free seats the LMS no longer reports -- but only on runs with no
+        # paid seat, so we never contend with an ecommerce-owned audit seat.
+        for run in filter(None, (course_run, course_run.draft_version)):
+            if not run.seats.exclude(type__slug__in=self.FREE_SEAT_TYPES).exists():
+                run.seats.filter(type__slug__in=self.FREE_SEAT_TYPES).exclude(type__slug__in=lms_free).delete()
 
 
 class EcommerceApiDataLoader(AbstractDataLoader):
@@ -562,11 +617,14 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             product_body = self.clean_strings(product_body)
             self.update_seat(course_run, product_body)
 
-        # Remove seats which no longer exist for that course run
+        # Remove seats which no longer exist for that course run. Honor seats are
+        # owned by the LMS-modes loader (CoursesApiDataLoader.update_free_seats),
+        # not ecommerce, so keep them even though no ecommerce product backs them.
         certificate_types = [self.get_certificate_type(product) for product in body['products']
                              if product['structure'] == 'child']
+        keep_types = [*certificate_types, Seat.HONOR]
 
-        seats_to_remove = course_run.seats.exclude(type__slug__in=certificate_types)
+        seats_to_remove = course_run.seats.exclude(type__slug__in=keep_types)
         if seats_to_remove.count() > 0:
             logger.info(
                 'Removing seats [%s] for course run with key [%s].',
@@ -576,7 +634,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
         seats_to_remove.delete()
 
         if course_run.draft_version:
-            draft_seats_to_remove = course_run.draft_version.seats.exclude(type__slug__in=certificate_types)
+            draft_seats_to_remove = course_run.draft_version.seats.exclude(type__slug__in=keep_types)
             draft_seats_to_remove.delete()
 
     def update_seat(self, course_run, product_body):

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -355,37 +355,67 @@ class CoursesApiDataLoader(AbstractDataLoader):
         modes = body.get('modes')
         if modes is None:
             return
-        lms_free = {mode.get('slug') for mode in modes if mode.get('slug') in self.FREE_SEAT_TYPES}
+        lms_free = {
+            mode.get('slug'): (mode.get('currency') or '').upper()
+            for mode in modes if mode.get('slug') in self.FREE_SEAT_TYPES
+        }
 
-        try:
-            currency = Currency.objects.get(code='USD')
-        except Currency.DoesNotExist:  # pragma: no cover
-            logger.warning('Default currency USD not found; skipping free-seat sync for [%s].', course_run.key)
-            return
-
-        for slug in lms_free:
+        for slug, currency_code in lms_free.items():
             try:
                 seat_type = SeatType.objects.get(slug=slug)
             except SeatType.DoesNotExist:
                 logger.warning('LMS reported unknown free seat type [%s] for run [%s]; skipping.', slug, course_run.key)
                 continue
-            seat, created = course_run.seats.update_or_create(
-                type=seat_type, currency=currency, defaults={'price': 0},
-            )
+            seat = self._ensure_free_seat(course_run, seat_type, currency_code, draft=False)
             if course_run.draft_version:
-                draft_seat, __ = course_run.draft_version.seats.update_or_create(
-                    draft=True, type=seat_type, currency=currency, defaults={'price': 0},
-                )
-                seat.draft_version = draft_seat
-                seat.save()
-            if created:
-                logger.info('Created free [%s] seat for run [%s] from LMS modes.', slug, course_run.key)
+                draft_seat = self._ensure_free_seat(course_run.draft_version, seat_type, currency_code, draft=True)
+                if seat and draft_seat and seat.draft_version_id != draft_seat.id:
+                    seat.draft_version = draft_seat
+                    seat.save()
 
         # Prune free seats the LMS no longer reports -- but only on runs with no
         # paid seat, so we never contend with an ecommerce-owned audit seat.
         for run in filter(None, (course_run, course_run.draft_version)):
             if not run.seats.exclude(type__slug__in=self.FREE_SEAT_TYPES).exists():
                 run.seats.filter(type__slug__in=self.FREE_SEAT_TYPES).exclude(type__slug__in=lms_free).delete()
+
+    def _ensure_free_seat(self, run, seat_type, currency_code, draft):
+        """
+        Return the run's free seat of `seat_type`, creating it at price 0 if absent.
+
+        Matches an existing seat by type only -- for a $0 seat the currency is
+        cosmetic, and reusing whatever is already present avoids creating a
+        duplicate against a migrated relic seat (e.g. an honor seat priced in
+        GBP on Global).
+        """
+        seat = run.seats.filter(type=seat_type).first()
+        if seat is not None:
+            if seat.price != 0:
+                seat.price = 0
+                seat.save()
+            return seat
+        currency = self._free_seat_currency(currency_code)
+        if currency is None:
+            logger.warning(
+                'No currency available to create free [%s] seat for run [%s]; skipping.', seat_type.slug, run.key,
+            )
+            return None
+        logger.info('Created free [%s] seat for run [%s] from LMS modes.', seat_type.slug, run.key)
+        return run.seats.create(type=seat_type, currency=currency, price=0, draft=draft)
+
+    @staticmethod
+    def _free_seat_currency(currency_code):
+        """
+        Resolve the Currency for a newly created free seat.
+
+        Prefers the code the LMS reported for the mode, falls back to USD.
+        Returns None only if neither exists in the catalog Currency table.
+        """
+        for code in filter(None, (currency_code, 'USD')):
+            currency = Currency.objects.filter(code=code).first()
+            if currency is not None:
+                return currency
+        return None
 
 
 class EcommerceApiDataLoader(AbstractDataLoader):

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -16,6 +16,7 @@ from edx_toggles.toggles.testutils import override_waffle_switch
 from pytz import UTC
 from slumber.exceptions import HttpClientError
 
+from course_discovery.apps.core.models import Currency
 from course_discovery.apps.core.tests.utils import mock_api_callback, mock_jpeg_callback
 from course_discovery.apps.course_metadata.choices import CourseRunPacing, CourseRunStatus
 from course_discovery.apps.course_metadata.data_loaders.api import (
@@ -1300,3 +1301,104 @@ class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         for program in programs:
             self.assert_program_loaded(program)
             self.assert_program_banner_image_loaded(program)
+
+
+class CoursesApiDataLoaderFreeSeatsTests(DataLoaderTestMixin, TestCase):
+    """
+    Tests for HARROW_6-4839: materialize free (honor/audit) seats from the
+    authoritative LMS enrollment modes (CoursesApiDataLoader.update_free_seats).
+    """
+    loader_class = CoursesApiDataLoader
+
+    @property
+    def api_url(self):
+        return self.partner.courses_api_url
+
+    def setUp(self):
+        super().setUp()
+        self.honor = SeatTypeFactory.honor()
+        self.audit = SeatTypeFactory.audit()
+        self.usd = Currency.objects.get(code='USD')
+
+    @staticmethod
+    def _body(*slugs, currency='USD'):
+        return {'modes': [{'slug': slug, 'min_price': 0, 'currency': currency} for slug in slugs]}
+
+    @staticmethod
+    def _empty_run():
+        run = CourseRunFactory()
+        run.seats.all().delete()
+        return run
+
+    def test_creates_free_seat_from_lms_mode(self):
+        run = self._empty_run()
+        self.loader.update_free_seats(run, self._body('honor'))
+        assert run.seats.count() == 1
+        seat = run.seats.get(type=self.honor)
+        assert seat.price == 0
+        assert seat.currency == self.usd
+
+    def test_matches_existing_seat_by_type_no_duplicate(self):
+        run = self._empty_run()
+        other_currency = Currency.objects.exclude(code='USD').first()
+        SeatFactory(course_run=run, type=self.honor, currency=other_currency, price=0)
+        self.loader.update_free_seats(run, self._body('honor'))
+        # Existing honor seat reused (matched by type) -- no duplicate in another currency.
+        assert run.seats.filter(type=self.honor).count() == 1
+        assert run.seats.get(type=self.honor).currency == other_currency
+
+    def test_prunes_free_seat_not_reported_on_unpaid_run(self):
+        run = self._empty_run()
+        SeatFactory(course_run=run, type=self.honor, currency=self.usd, price=0)
+        SeatFactory(course_run=run, type=self.audit, currency=self.usd, price=0)
+        self.loader.update_free_seats(run, self._body('honor'))
+        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.HONOR}
+
+    def test_does_not_prune_free_seat_when_paid_seat_present(self):
+        run = self._empty_run()
+        SeatFactory(course_run=run, type=SeatTypeFactory.professional(), currency=self.usd)
+        SeatFactory(course_run=run, type=self.honor, currency=self.usd, price=0)
+        # LMS reports no free modes; honor must survive because a paid seat exists.
+        self.loader.update_free_seats(run, {'modes': []})
+        assert run.seats.filter(type=self.honor).exists()
+
+    def test_noop_when_modes_key_absent(self):
+        run = self._empty_run()
+        SeatFactory(course_run=run, type=self.honor, currency=self.usd, price=0)
+        self.loader.update_free_seats(run, {})
+        assert run.seats.filter(type=self.honor).count() == 1
+
+    def test_currency_falls_back_to_usd(self):
+        run = self._empty_run()
+        self.loader.update_free_seats(run, self._body('honor', currency='ZZZ'))
+        assert run.seats.get(type=self.honor).currency == self.usd
+
+    def test_idempotent(self):
+        run = self._empty_run()
+        body = self._body('honor')
+        self.loader.update_free_seats(run, body)
+        self.loader.update_free_seats(run, body)
+        assert run.seats.filter(type=self.honor).count() == 1
+
+
+class EcommerceApiDataLoaderKeepHonorTests(DataLoaderTestMixin, TestCase):
+    """
+    HARROW_6-4839: the ecommerce loader must not delete LMS-owned honor seats
+    (they are materialized by CoursesApiDataLoader.update_free_seats, not backed
+    by an ecommerce product).
+    """
+    loader_class = EcommerceApiDataLoader
+
+    @property
+    def api_url(self):
+        return self.partner.ecommerce_api_url
+
+    def test_update_seats_keeps_honor_seat(self):
+        run = CourseRunFactory()
+        run.seats.all().delete()
+        usd = Currency.objects.get(code='USD')
+        SeatFactory(course_run=run, type=SeatTypeFactory.honor(), currency=usd, price=0)
+        SeatFactory(course_run=run, type=SeatTypeFactory.audit(), currency=usd, price=0)
+        # No ecommerce products for this run: honor is kept, the unbacked audit removed.
+        self.loader.update_seats({'id': run.key, 'products': []})
+        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.HONOR}


### PR DESCRIPTION
> ✅ **SELECTED approach (B) for HARROW_6-4839** — chosen over the self-heal [#18](https://github.com/raccoongang/course-discovery/pull/18).

## Summary

- **Alternative (R1)** to the self-heal PR (#18): fix the root cause. On Teak, discovery derives seats only from ecommerce, which has no products for free courses — so free-course runs end up seatless and **untypeable**, which aborts the whole `refresh_course_metadata` (`CommandError`).
- `CoursesApiDataLoader.update_free_seats()` — materialize honor/audit seats from the authoritative LMS `modes` payload. Matches an existing free seat **by type** (reuses a migration relic instead of duplicating it in another currency), stamps new seats with the LMS-reported currency (falls back to USD), and prunes free seats the LMS no longer reports — only on runs with no paid seat.
- `EcommerceApiDataLoader.update_seats()` — never delete LMS-owned honor seats.
- Companion `edx-platform` MR exposes `modes` in the courses API. **No-op until both are deployed.**

## Tests

Added `CoursesApiDataLoaderFreeSeatsTests` and `EcommerceApiDataLoaderKeepHonorTests` in `data_loaders/tests/test_api.py`:
- create honor seat from an LMS mode (currency USD, price 0)
- match-by-type: an existing relic seat in another currency is reused, not duplicated
- prune an audit seat the LMS no longer reports (run with no paid seat)
- prune is skipped when a paid seat is present
- no-op when the payload has no `modes` key
- currency falls back to USD for an unknown code
- idempotent (second run creates nothing)
- ecommerce `update_seats` keeps an LMS-owned honor seat

## Verified — harrowcn-dev, red→green

- Seeded an unmatchable free run (`{honor, audit}`) → `refresh_course_metadata` aborts with `CommandError: Ecommerce Data Loader failed` (same error as PRODGT). ✅ reproduced
- Applied both changes → refresh exits 0; run typed `honor` (audit pruned, honor kept, **no duplicate**), currency `USD`. ✅
- Fresh seatless run + LMS honor mode → `Created free [honor] seat ... from LMS modes`, typed `honor`. ✅ create path
- Second refresh → no duplicate creation. ✅ idempotent
- Ecommerce seats (professional, sku) and pre-existing honor relics untouched. ✅ no regression

## Prod pre-flight (harrow-prod, read-only)

Simulated over the full catalog: **0 runs become untypeable**; 561 honor seats created (fix), 2 orphan relics pruned (benign). Details in the ticket.

## Risks

- Prune removes a free (honor/audit) relic seat on a run with **no paid seat** when the LMS reports no matching mode — intended (LMS is source of truth), but it does change existing data for misconfigured courses that carry a relic seat with no backing LMS mode.

## Related MRs

- `edx-platform` -- [!33](https://gitlab.raccoongang.com/hippoteam/harrow/teak/edx-platform/-/merge_requests/33) -- expose `modes` in courses API (companion, required)
- `course-discovery` -- [#18](https://github.com/raccoongang/course-discovery/pull/18) -- **alternative** self-heal approach; not chosen
- `course-discovery` -- [#20](https://github.com/raccoongang/course-discovery/pull/20) -- **follow-up fix**: this PR let the ecommerce loader keep only `honor`, so on realms whose free mode is `audit` the seat was created and pruned every cycle (broke the Global stage cron)

## Ticket

- [HARROW_6-4839](https://youtrack.raccoongang.com/issue/HARROW_6-4839) -- discovery refresh_course_metadata cron fails on PRODGT

