### PR TITLE
fix: [HARROW_6-4839] keep LMS-owned audit seats in the ecommerce loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -27,6 +27,13 @@ from course_discovery.apps.course_metadata.utils import push_to_ecommerce_for_co
 
 logger = logging.getLogger(__name__)
 
+# Free enrollment modes whose seats are owned by the LMS loader
+# (CoursesApiDataLoader.update_free_seats) rather than by the ecommerce loader.
+# Ecommerce carries no products for these on free courses, so the LMS CourseMode
+# table is their only source of truth -- and the ecommerce loader must therefore
+# leave them alone instead of pruning them as product-less.
+FREE_SEAT_TYPES = frozenset({Seat.HONOR, Seat.AUDIT})
+
 
 def _fatal_code(ex):
     """
@@ -338,11 +345,6 @@ class CoursesApiDataLoader(AbstractDataLoader):
 
         return video
 
-    # Free enrollment modes whose seats are owned by this (LMS) loader rather
-    # than by the ecommerce loader. Ecommerce carries no products for these on
-    # free courses, so the LMS CourseMode table is their only source of truth.
-    FREE_SEAT_TYPES = frozenset({Seat.HONOR, Seat.AUDIT})
-
     def update_free_seats(self, course_run, body):
         """
         Sync a run's free (honor/audit) seats from the authoritative LMS modes.
@@ -357,7 +359,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             return
         lms_free = {
             mode.get('slug'): (mode.get('currency') or '').upper()
-            for mode in modes if mode.get('slug') in self.FREE_SEAT_TYPES
+            for mode in modes if mode.get('slug') in FREE_SEAT_TYPES
         }
 
         for slug, currency_code in lms_free.items():
@@ -374,10 +376,11 @@ class CoursesApiDataLoader(AbstractDataLoader):
                     seat.save()
 
         # Prune free seats the LMS no longer reports -- but only on runs with no
-        # paid seat, so we never contend with an ecommerce-owned audit seat.
+        # paid seat: there a free seat can belong to an ecommerce-backed track set
+        # (verified-audit carries an audit child product), so it is not ours to drop.
         for run in filter(None, (course_run, course_run.draft_version)):
-            if not run.seats.exclude(type__slug__in=self.FREE_SEAT_TYPES).exists():
-                run.seats.filter(type__slug__in=self.FREE_SEAT_TYPES).exclude(type__slug__in=lms_free).delete()
+            if not run.seats.exclude(type__slug__in=FREE_SEAT_TYPES).exists():
+                run.seats.filter(type__slug__in=FREE_SEAT_TYPES).exclude(type__slug__in=lms_free).delete()
 
     def _ensure_free_seat(self, run, seat_type, currency_code, draft):
         """
@@ -647,12 +650,12 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             product_body = self.clean_strings(product_body)
             self.update_seat(course_run, product_body)
 
-        # Remove seats which no longer exist for that course run. Honor seats are
+        # Remove seats which no longer exist for that course run. Free seats are
         # owned by the LMS-modes loader (CoursesApiDataLoader.update_free_seats),
         # not ecommerce, so keep them even though no ecommerce product backs them.
         certificate_types = [self.get_certificate_type(product) for product in body['products']
                              if product['structure'] == 'child']
-        keep_types = [*certificate_types, Seat.HONOR]
+        keep_types = [*certificate_types, *FREE_SEAT_TYPES]
 
         seats_to_remove = course_run.seats.exclude(type__slug__in=keep_types)
         if seats_to_remove.count() > 0:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -1381,24 +1381,58 @@ class CoursesApiDataLoaderFreeSeatsTests(DataLoaderTestMixin, TestCase):
         assert run.seats.filter(type=self.honor).count() == 1
 
 
-class EcommerceApiDataLoaderKeepHonorTests(DataLoaderTestMixin, TestCase):
+class EcommerceApiDataLoaderKeepFreeSeatsTests(DataLoaderTestMixin, TestCase):
     """
-    HARROW_6-4839: the ecommerce loader must not delete LMS-owned honor seats
+    HARROW_6-4839: the ecommerce loader must not delete LMS-owned free seats
     (they are materialized by CoursesApiDataLoader.update_free_seats, not backed
     by an ecommerce product).
     """
     loader_class = EcommerceApiDataLoader
 
+    @staticmethod
+    def _seatless_run():
+        run = CourseRunFactory()
+        run.seats.all().delete()
+        return run
+
     @property
     def api_url(self):
         return self.partner.ecommerce_api_url
 
-    def test_update_seats_keeps_honor_seat(self):
-        run = CourseRunFactory()
-        run.seats.all().delete()
+    def test_update_seats_keeps_free_seats(self):
+        run = self._seatless_run()
         usd = Currency.objects.get(code='USD')
         SeatFactory(course_run=run, type=SeatTypeFactory.honor(), currency=usd, price=0)
         SeatFactory(course_run=run, type=SeatTypeFactory.audit(), currency=usd, price=0)
-        # No ecommerce products for this run: honor is kept, the unbacked audit removed.
+        # No ecommerce products for this run: both free seats are LMS-owned and kept.
         self.loader.update_seats({'id': run.key, 'products': []})
-        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.HONOR}
+        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.HONOR, Seat.AUDIT}
+
+    def test_update_seats_still_removes_unbacked_paid_seat(self):
+        run = self._seatless_run()
+        SeatFactory(course_run=run, type=SeatTypeFactory.professional(), currency=Currency.objects.get(code='USD'))
+        self.loader.update_seats({'id': run.key, 'products': []})
+        assert not run.seats.exists()
+
+    def test_audit_seat_survives_a_full_loader_cycle(self):
+        """
+        Regression for the create-then-delete thrash seen on Global stage.
+
+        The LMS loader materializes an audit seat from the reported modes; the
+        ecommerce loader then runs over the same seatless-in-ecommerce run and
+        must leave that seat in place. Otherwise the run ends every cycle with
+        no seats and its course stays untypeable, aborting the whole ingest.
+        """
+        run = self._seatless_run()
+        # Same JWT stub the mixin uses for its own loader -- the constructor
+        # decodes the mocked access token to resolve the service username.
+        with mock.patch(
+            'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
+            return_value={'preferred_username': 'test_username'},
+        ):
+            courses_loader = CoursesApiDataLoader(self.partner, self.partner.courses_api_url)
+        courses_loader.update_free_seats(run, {'modes': [{'slug': 'audit', 'min_price': 0, 'currency': 'usd'}]})
+        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.AUDIT}
+
+        self.loader.update_seats({'id': run.key, 'products': []})
+        assert set(run.seats.values_list('type__slug', flat=True)) == {Seat.AUDIT}


### PR DESCRIPTION
## What

Follow-up regression fix for the free-seat work in #19.

`CoursesApiDataLoader.update_free_seats()` materializes both members of
`FREE_SEAT_TYPES` (`honor`, `audit`) from the LMS enrollment modes, but
`EcommerceApiDataLoader.update_seats()` protected only `Seat.HONOR` from the
product-less prune. On realms whose free mode is `audit`, the two loaders fought
every refresh cycle:

```
api.py:403 - Created free [audit] seat for run [course-v1:RG+CS10+05] from LMS modes.
api.py:659 - Removing seats [audit] for course run with key [course-v1:RG+CS10+05].
```

The run ended each cycle seatless, so its course kept a mixed seated/seatless run
set. That matches no `CourseType` (`_is_matching_run_type` compares seat-type sets
for equality, and the only run type with an empty set is `empty`, which belongs to
no real course type), `calculate_course_type` returned `False`, and the whole
ecommerce ingest aborted.

Changes:

- `FREE_SEAT_TYPES` hoisted to module scope — both loaders read it now.
- `keep_types` protects the full free set instead of `honor` alone.
- `test_update_seats_keeps_honor_seat` asserted the defect (it expected the audit
  seat to be removed) — corrected, plus a regression test that runs a full
  LMS-then-ecommerce cycle and a guard that unbacked *paid* seats are still pruned.

Why #19's verification missed it: it was verified red→green on harrowcn-dev, where
the free mode is `honor` — the protected one. Global stage uses `audit`.

## Verify

Unit tests (the fork's CI never reaches the test step — `make ci_up` fails building
the image on `apt-add-repository ppa:deadsnakes`, so this was run in the
`discovery:harrow-0.7.0` image with `requirements/test.txt` and an ES 7.17 sidecar):

```bash
pytest course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
# 67 passed, 2 failed
```

The 2 failures are `CoursesApiDataLoaderTests::test_ingest_handles_draft_{3,7}` and
are **pre-existing on `harrow-main`** — verified by running them on a clean
worktree at `f384cda11` (same 2 fail, 6 pass). They are a `canonical_course_run`
`IntegrityError` swallowed inside an atomic block, unrelated to this change.

On `harrow-stage` (cron had been red for 5 days): this file was mounted over the
`discovery:harrow-0.7.0` image via a ConfigMap `subPath` in a one-off Job cloned
from the refresh cronjob, and the loader run once. Result — no `Removing seats`,
and:

```
course_type.py:90 - Course RG+CS10 (6) matched type Audit Only
course_type.py:90 - Course AISL.Academy+Nn101 (12) matched type Audit Only
```

Job `Completed`, no `Processing failure` / `CommandError`. The scheduled cron has
been green since.

## Risks

- Behaviour change for paid runs: a free seat on a run that also has a paid seat is
  now kept by `update_seats` even when ecommerce stops carrying its child product
  (e.g. an `audit` track of a `verified-audit` run). This is the safer direction —
  previously the seat was deleted and the run's frozen `verified-audit` type then
  mismatched its own seats, which aborts the ingest.
- Known limitation, unchanged from #19: on a run that carries a paid seat, the LMS
  prune step is skipped, so a free seat the LMS no longer reports lingers. It does
  not break typing; noted for the durable follow-up.
- Does not address the wider class this exposed: a course with a mix of seated and
  seatless runs can never match a `CourseType`, and a run whose LMS course has no
  `CourseMode` at all never gets a free seat (28 of 61 runs on Global stage). That
  wants the resilience part (per-object skip instead of aborting the ingest) carried
  from #18, or the follow-up ticket already noted on HARROW_6-4839.

## Related MRs

- `edx-platform` -- [!33](https://gitlab.raccoongang.com/hippoteam/harrow/teak/edx-platform/-/merge_requests/33) ✅ merged -- exposes `modes` in the courses API (Approach B, companion of #19)
- `course-discovery` -- [#19](https://github.com/raccoongang/course-discovery/pull/19) ✅ merged -- the free-seat fix this one repairs
- `course-discovery` -- [#18](https://github.com/raccoongang/course-discovery/pull/18) -- open; Approach A (self-heal), not chosen, carries the B1 resilience this fix does not

## Ticket

- [HARROW_6-4839](https://youtrack.raccoongang.com/issue/HARROW_6-4839) -- [Global] discovery refresh_course_metadata cron fails again on PRODGT (recurrence of HARROW_6-4745)